### PR TITLE
deps: bump version of nodemailer

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "colors": "^1.1.2",
     "dateformat": "^1.0.12",
     "lodash": "^4.6.1",
-    "nodemailer": "^2.3.0",
+    "nodemailer": "^4.6.0",
     "stripcolorcodes": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The nodemailer version has increased to a supported version.

Closes https://github.com/natergj/sloth-logger/issues/1